### PR TITLE
chore: using base64 to encode the user and password

### DIFF
--- a/src/main/java/org/forrest/EventWebhookProvider.java
+++ b/src/main/java/org/forrest/EventWebhookProvider.java
@@ -14,7 +14,7 @@ import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.RealmProvider;
 
 import java.io.IOException;
-import java.util.Arrays;
+import java.util.Base64;
 
 public class EventWebhookProvider implements EventListenerProvider {
     private static final Logger log = Logger.getLogger(EventWebhookProvider.class);
@@ -110,7 +110,9 @@ public class EventWebhookProvider implements EventListenerProvider {
                     .addHeader("User-Agent", "Keycloak Event Webhook");
 
             if (config.getUsername() != null && config.getPassword() != null) {
-                builder.addHeader("Authorization", "Basic " + config.getUsername() + ":" + Arrays.toString(config.getPassword().toCharArray()));
+                String sourceString = config.getUsername() + ":" + config.getPassword();
+	            String encodedString = Base64.getEncoder().encodeToString(sourceString.getBytes());
+                builder.addHeader("Authorization", "Basic " + encodedString);
             }
 
             Request request = builder.post(formBody)


### PR DESCRIPTION
Hey @ForrestRolf thanks for this extension, its working really well, the only thing I wasn't expecting is the basic auth should be encoded to base64, so this PR is to fix that and be compliant with the specification.

I've tested this extension with Keycloak 20.0 and its working find, I'm still figuring out how to run Keycloak in dev mode and test properly extensions like this.

https://developer.mozilla.org/en-US/docs/Web/HTTP/Authentication#basic_authentication_scheme